### PR TITLE
uint, bcrypt.lib

### DIFF
--- a/src/Headers/common.h
+++ b/src/Headers/common.h
@@ -27,6 +27,10 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 
+#pragma comment(lib, "bcrypt.lib")
+
+typedef unsigned int uint;
+
 // uuid namespaces
 namespace uuids = boost::uuids;
 


### PR DESCRIPTION
te 2 linijki umożliwiają kompilację pod windowsem przy pomocy vcpkg, cmake oraz visual studio.
przy konfiguracji cmake trzeba podać ściężkę z vcpkg do pliku z cmake toolchain